### PR TITLE
Fix wrapper and clean up build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,3 @@
-group = 'org.examples.java'
-version = '1.0-SNAPSHOT'
-
-apply plugin: 'java'
-apply plugin:'application'
-apply plugin: 'com.bmuschko.docker-remote-api'
-
-import com.bmuschko.gradle.docker.tasks.container.*
-import com.bmuschko.gradle.docker.tasks.image.*
-
-mainClassName = "org.examples.java.App"
-
 buildscript {
     repositories {
         jcenter()
@@ -20,35 +8,25 @@ buildscript {
     }
 }
 
+apply plugin: 'java'
+apply plugin: 'application'
+apply plugin: 'com.bmuschko.docker-java-application'
+
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+group = 'org.examples.java'
+version = '1.0-SNAPSHOT'
+
+mainClassName = "org.examples.java.App"
+
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.+'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
-jar {
-    manifest {
-        attributes 'Main-Class': 'org.examples.java.App'
+docker {
+    javaApplication {
+        baseImage = 'openjdk:latest'
+        tag = 'hellojava'
     }
 }
-
-task createDockerfile(type: Dockerfile) {
-    destFile = project.file('build/Dockerfile')
-    from 'openjdk'   
-}
-
-task copyDockerArtifacts(type: Copy) {
-    dependsOn build
-
-    from('build/libs') {
-        include "docker-java-sample-${project.version}.war"
-    }
-}
-
-task buildImage(type: DockerBuildImage) {
-    dependsOn copyDockerArtifacts
-    inputDir = project.file('build/docker')
-    tag = 'hellojava'
-}
-

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 07 19:44:20 CEST 2016
+#Sat Feb 11 09:39:35 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-bin.zip

--- a/gradlew
+++ b/gradlew
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 ##############################################################################
 ##
@@ -154,16 +154,19 @@ if $cygwin ; then
     esac
 fi
 
-# Split up the JVM_OPTS And GRADLE_OPTS values into an array, following the shell quoting and substitution rules
-function splitJvmOpts() {
-    JVM_OPTS=("$@")
+# Escape application args
+save ( ) {
+    for i do printf %s\\n "$i" | sed "s/'/'\\\\''/g;1s/^/'/;\$s/\$/' \\\\/" ; done
+    echo " "
 }
-eval splitJvmOpts $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS
-JVM_OPTS[${#JVM_OPTS[*]}]="-Dorg.gradle.appname=$APP_BASE_NAME"
+APP_ARGS=$(save "$@")
+
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- $DEFAULT_JVM_OPTS $JAVA_OPTS $GRADLE_OPTS "\"-Dorg.gradle.appname=$APP_BASE_NAME\"" -classpath "\"$CLASSPATH\"" org.gradle.wrapper.GradleWrapperMain "$APP_ARGS"
 
 # by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
-if [[ "$(uname)" == "Darwin" ]] && [[ "$HOME" == "$PWD" ]]; then
+if [ "$(uname)" = "Darwin" ] && [ "$HOME" = "$PWD" ]; then
   cd "$(dirname "$0")"
 fi
 
-exec "$JAVACMD" "${JVM_OPTS[@]}" -classpath "$CLASSPATH" org.gradle.wrapper.GradleWrapperMain "$@"
+exec "$JAVACMD" "$@"


### PR DESCRIPTION
I changed the following:

- Fix the Wrapper by updating to the latest version. There're was something with the Wrapper JAR file that you had checked in. I saw the following error message before: `Error: Could not find or load main class org.gradle.wrapper.GradleWrapperMain`.
- Use the [Docker Application Plugin](https://github.com/bmuschko/gradle-docker-plugin#java-application-plugin) which already does all the configuration for your Java application out-of-the-box. It basically sits on the top of the Remote Plugin and creates/preconfigures the tasks you created in your build script. If you can live with the conventions then you are good to go (though their are configurable to a certain extent).
- Side note on your dependency declaration: I'd stay away from using dynamic versions e.g. `4.+` as they potentially break your build in the future. If the API changes with a newer version of JUnit that's not compatible with the API your are using then you'd have a problem.